### PR TITLE
Parse local CRL file

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -78,3 +78,11 @@ Revoked Certificates:
 ```
 
 The `Revoked Certificates` don't seem to be sorted by `Revocation Date`.
+
+## Ruby Parsing Attempts
+
+File sizes:
+
+  + `.crl` file: 13M
+  + `metadata.json` file: 315B
+  + `revocations.json` file: 75M

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -83,6 +83,7 @@ The `Revoked Certificates` don't seem to be sorted by `Revocation Date`.
 
 File sizes:
 
-  + `.crl` file: 13M
-  + `metadata.json` file: 315B
-  + `revocations.json` file: 75M
+  + `.crl`: 13M
+  + `metadata.json`: 315B
+  + `revocations.json`: 75M (with extensions)
+  + `revocations.csv`: 9.1M (without extensions)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -87,3 +87,4 @@ File sizes:
   + `metadata.json`: 315B
   + `revocations.json`: 75M (with extensions)
   + `revocations.csv`: 9.1M (without extensions)
+  + `revocations.csv`: 21M (with extensions)

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -3,6 +3,7 @@
   + [OpenSSL Docs](https://www.openssl.org/docs/man1.1.0/apps/crl.html)
   + [Ruby OpenSSL Source](https://github.com/ruby/openssl)
   + [Ruby `OpenSSL::X509::CRL` Docs](https://ruby-doc.org/stdlib-2.4.2/libdoc/openssl/rdoc/OpenSSL/X509/CRL.html)
+  + [Ruby `OpenSSL::X509::Revoked` Docs](http://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/X509/Revoked.html)
   + [Parsing a CRL with OpenSSL](https://langui.sh/2010/01/10/parsing-a-crl-with-openssl/)
   + [Reading CRLs in Windows with Ruby](http://seanbachelder.me/2016/06/17/reading-crls-in-windows-with-ruby.html)
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,13 +1,22 @@
 # Credits, Notes, and Reference
 
+Documentation:
+
   + [OpenSSL Docs](https://www.openssl.org/docs/man1.1.0/apps/crl.html)
   + [Ruby OpenSSL Source](https://github.com/ruby/openssl)
   + [Ruby `OpenSSL::X509::CRL` Docs](https://ruby-doc.org/stdlib-2.4.2/libdoc/openssl/rdoc/OpenSSL/X509/CRL.html)
   + [Ruby `OpenSSL::X509::Revoked` Docs](http://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/X509/Revoked.html)
+  + [Ruby `OpenSSL::X509::Extension` Docs](http://ruby-doc.org/stdlib-2.5.0/libdoc/openssl/rdoc/OpenSSL/X509/Extension.html)
+  + [Ruby `OpenSSL::BN` (Serial Number) Docs](http://ruby-doc.org/stdlib-2.4.0/libdoc/openssl/rdoc/OpenSSL/BN.html)
+
+Tutorials, examples, and guides:
+
   + [Parsing a CRL with OpenSSL](https://langui.sh/2010/01/10/parsing-a-crl-with-openssl/)
   + [Reading CRLs in Windows with Ruby](http://seanbachelder.me/2016/06/17/reading-crls-in-windows-with-ruby.html)
 
 ## Initial Parsing Attempts
+
+When opening the CRL file in a text editor, it appears to be binary, which would suggest it's in DER format (not PEM format).
 
 Using the command-line to parse a CRL from file:
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "openssl"
+gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,19 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    coderay (1.1.2)
+    method_source (0.9.0)
+    openssl (2.1.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  openssl
+  pry
+
+BUNDLED WITH
+   1.16.1

--- a/data/20180301-1544/metadata.json
+++ b/data/20180301-1544/metadata.json
@@ -1,0 +1,9 @@
+{
+  "issuer": "/C=US/O=U.S. Government/OU=DoD/OU=PKI/CN=DOD ID CA-42",
+  "version": "1",
+  "last_update": "2018-03-01 08:00:00 UTC",
+  "next_update": "2018-03-08 17:00:00 UTC",
+  "revocations_count": 306926,
+  "earlist_revocation_at": "2016-06-10 14:08:32 UTC",
+  "latest_revocation_at": "2018-03-01 07:47:29 UTC"
+}

--- a/data/20180301-1544/metadata.json
+++ b/data/20180301-1544/metadata.json
@@ -4,6 +4,6 @@
   "last_update": "2018-03-01 08:00:00 UTC",
   "next_update": "2018-03-08 17:00:00 UTC",
   "revocations_count": 306926,
-  "earlist_revocation_at": "2016-06-10 14:08:32 UTC",
+  "earliest_revocation_at": "2016-06-10 14:08:32 UTC",
   "latest_revocation_at": "2018-03-01 07:47:29 UTC"
 }

--- a/jobs/parser.rb
+++ b/jobs/parser.rb
@@ -59,14 +59,14 @@ puts "PARSING REVOKED CERTIFICATES..."
 #
 
 revocations_filepath = File.join(crl_dir, "revocations.csv")
-headers = ["serial_number", "revoked_at"] # todo: think about how to add "extensions" as well
+headers = ["serial_number", "revoked_at", "extensions"]
 
 CSV.open(revocations_filepath, "w", :write_headers=> true, :headers => headers) do |csv|
   revocations.each do |revocation|
     csv << [
       revocation.serial.to_s,
-      revocation.time.to_s #,
-      #revocation.extensions.map{ |ext| ext.to_h }
+      revocation.time.to_s,
+      revocation.extensions.map{|ext| ext.to_s }.join(" | ") # pipe-delimited string like "CRLReason = Cessation Of Operation | invalidityDate = ..20160610050000Z"
     ]
   end
 end

--- a/jobs/parser.rb
+++ b/jobs/parser.rb
@@ -1,5 +1,6 @@
 require "openssl"
 require "json"
+require "csv"
 require "pry"
 
 CRL_URL = "http://crl.disa.mil/crl/DODIDCA_42.crl" # this is the only CRL URL I know about at the moment.
@@ -35,16 +36,37 @@ end
 
 puts "PARSING REVOKED CERTIFICATES..."
 
-revs = [] # maybe faster than mapping 300K items in place...
-revocations.each do |revocation|
-  revs << {
-    serial_number: revocation.serial.to_s,
-    revoked_at: revocation.time.to_s,
-    extensions: revocation.extensions.map{ |ext| ext.to_h }
-  }
-end
+#
+# REVOCATIONS.JSON
+#
+#
+#revs = [] # maybe faster than mapping 300K items in place...
+#revocations.each do |revocation|
+#  revs << {
+#    serial_number: revocation.serial.to_s,
+#    revoked_at: revocation.time.to_s,
+#    extensions: revocation.extensions.map{ |ext| ext.to_h }
+#  }
+#end
+#
+#revocations_filepath = File.join(crl_dir, "revocations.json")
+#File.open(revocations_filepath ,"w") do |f|
+#  f.write(JSON.pretty_generate(revs)) # is there a way to write incrementally?
+#end
 
-revocations_filepath = File.join(crl_dir, "revocations.json")
-File.open(revocations_filepath ,"w") do |f|
-  f.write(JSON.pretty_generate(revs)) # is there a way to write incrementally?
+#
+# REVOCATIONS.CSV
+#
+
+revocations_filepath = File.join(crl_dir, "revocations.csv")
+headers = ["serial_number", "revoked_at"] # todo: think about how to add "extensions" as well
+
+CSV.open(revocations_filepath, "w", :write_headers=> true, :headers => headers) do |csv|
+  revocations.each do |revocation|
+    csv << [
+      revocation.serial.to_s,
+      revocation.time.to_s #,
+      #revocation.extensions.map{ |ext| ext.to_h }
+    ]
+  end
 end

--- a/jobs/parser.rb
+++ b/jobs/parser.rb
@@ -1,12 +1,38 @@
-
-#require "openssl"
+require "openssl"
+require "pry"
 
 CRL_URL = "http://crl.disa.mil/crl/DODIDCA_42.crl" # this is the only CRL URL I know about at the moment.
 
-puts "FETCHING CERTIFICATE REVOCATION LIST FROM #{CRL_URL}"
+puts "FETCHING CERTIFICATE REVOCATION LIST FROM #{CRL_URL}..."
 
 crl_filepath = "./data/20180301-1544/DODIDCA_42.crl" # NOTE: file when opened with a text editor appears to be binary, which would indicate the DER format (not the PEM format)
 
-puts "DOWNLOADED CERTIFICATE REVOCATION LIST TO #{crl_filepath}"
+puts "DOWNLOADED CERTIFICATE REVOCATION LIST TO #{crl_filepath}..."
 
-#parsed_crl = R509::CRL::SignedList.new(crl)
+puts "PARSING CRL FILE..."
+
+crl = OpenSSL::X509::CRL::new(File.read(crl_filepath))
+
+puts "... ISSUER: #{crl.issuer.to_s}"
+puts "... VERSION: #{crl.version.to_s}"
+puts "... LAST UPDATE: #{crl.last_update.to_s}"
+puts "... NEXT UPDATE: #{crl.next_update.to_s}"
+revoked_certs = crl.revoked # memoize for performance
+puts "... REVOKED CERTIFICATE COUNT: #{revoked_certs.count}"
+
+#puts "... LOOPING THROUGH REVOKED CERTIFICATES ..."
+
+#crl.revoked.each do |revoked_cert|
+#
+#end
+
+puts "INVESTIGATING FIRST CERTIFICATE..."
+
+r = revoked_certs.first
+
+puts "... SERIAL: #{r.serial.to_s}"
+puts "... TIME: #{r.time.to_s}"
+puts "... EXTENSIONS (#{r.extensions.count}):"
+r.extensions.each do |ext|
+  puts "   ... #{ext.to_h}"
+end

--- a/jobs/parser.rb
+++ b/jobs/parser.rb
@@ -33,18 +33,18 @@ File.open(metadata_filepath, "w") do |f|
   f.write(JSON.pretty_generate(metadata))
 end
 
-#puts "PARSING REVOKED CERTIFICATES..."
-#
-#r = []
-#revocations.each do |revocation|
-#  r << {
-#    serial_number: revocation.serial.to_s,
-#    revoked_at: revocation.time.to_s,
-#    extensions: revocation.extensions.map{ |ext| ext.to_h }
-#  }
-#end
-#
-#revocations_filepath = File.join(crl_dir, "revocations.json")
-#File.open(revocations_filepath ,"w") do |f|
-#  f.write(r.to_json)
-#end
+puts "PARSING REVOKED CERTIFICATES..."
+
+revs = [] # maybe faster than mapping 300K items in place...
+revocations.each do |revocation|
+  revs << {
+    serial_number: revocation.serial.to_s,
+    revoked_at: revocation.time.to_s,
+    extensions: revocation.extensions.map{ |ext| ext.to_h }
+  }
+end
+
+revocations_filepath = File.join(crl_dir, "revocations.json")
+File.open(revocations_filepath ,"w") do |f|
+  f.write(JSON.pretty_generate(revs)) # is there a way to write incrementally?
+end

--- a/jobs/parser.rb
+++ b/jobs/parser.rb
@@ -23,7 +23,7 @@ metadata = {
   last_update: crl.last_update.to_s,
   next_update: crl.next_update.to_s,
   revocations_count: revocations.count, #> 306926
-  earlist_revocation_at: revocations.first.time,
+  earliest_revocation_at: revocations.first.time,
   latest_revocation_at: revocations.last.time
 }
 

--- a/jobs/parser.rb
+++ b/jobs/parser.rb
@@ -1,4 +1,5 @@
 require "openssl"
+require "json"
 require "pry"
 
 CRL_URL = "http://crl.disa.mil/crl/DODIDCA_42.crl" # this is the only CRL URL I know about at the moment.
@@ -12,23 +13,38 @@ puts "DOWNLOADING CERTIFICATE REVOCATION LIST TO #{crl_filepath}..."
 puts "PARSING CERTIFICATE REVOCATION LIST..."
 
 crl = OpenSSL::X509::CRL::new(File.read(crl_filepath))
-revocations = crl.revoked.map { |revocation|
-  {
-    serial_number: revocation.serial.to_s,
-    revoked_at: revocation.time.to_s,
-    extensions: revocation.extensions.map{ |ext| ext.to_h }
-  }
-} #.sort_by{ |r| r[:_____]}
+revocations = crl.revoked
+revocations = revocations.sort_by{ |revocation| revocation.time }
 
 metadata = {
   issuer: crl.issuer.to_s,
   version: crl.version.to_s,
   last_update: crl.last_update.to_s,
   next_update: crl.next_update.to_s,
-  revocations_count: revocations.count,
-  earlist_revocation_at: revocations.first[:revoked_at],
-  latest_revocation_at: revocations.last[:revoked_at],
-  revocations: revocations
+  revocations_count: revocations.count, #> 306926
+  earlist_revocation_at: revocations.first.time,
+  latest_revocation_at: revocations.last.time
 }
 
 pp metadata
+
+metadata_filepath = File.join(crl_dir, "metadata.json")
+File.open(metadata_filepath, "w") do |f|
+  f.write(JSON.pretty_generate(metadata))
+end
+
+#puts "PARSING REVOKED CERTIFICATES..."
+#
+#r = []
+#revocations.each do |revocation|
+#  r << {
+#    serial_number: revocation.serial.to_s,
+#    revoked_at: revocation.time.to_s,
+#    extensions: revocation.extensions.map{ |ext| ext.to_h }
+#  }
+#end
+#
+#revocations_filepath = File.join(crl_dir, "revocations.json")
+#File.open(revocations_filepath ,"w") do |f|
+#  f.write(r.to_json)
+#end

--- a/jobs/parser.rb
+++ b/jobs/parser.rb
@@ -2,37 +2,33 @@ require "openssl"
 require "pry"
 
 CRL_URL = "http://crl.disa.mil/crl/DODIDCA_42.crl" # this is the only CRL URL I know about at the moment.
-
 puts "FETCHING CERTIFICATE REVOCATION LIST FROM #{CRL_URL}..."
 
-crl_filepath = "./data/20180301-1544/DODIDCA_42.crl" # NOTE: file when opened with a text editor appears to be binary, which would indicate the DER format (not the PEM format)
+downloaded_at = "20180301-1544" #TODO: vary over time
+crl_dir = "./data/#{downloaded_at}"
+crl_filepath = File.join(crl_dir, "DODIDCA_42.crl")
+puts "DOWNLOADING CERTIFICATE REVOCATION LIST TO #{crl_filepath}..."
 
-puts "DOWNLOADED CERTIFICATE REVOCATION LIST TO #{crl_filepath}..."
-
-puts "PARSING CRL FILE..."
+puts "PARSING CERTIFICATE REVOCATION LIST..."
 
 crl = OpenSSL::X509::CRL::new(File.read(crl_filepath))
+revocations = crl.revoked.map { |revocation|
+  {
+    serial_number: revocation.serial.to_s,
+    revoked_at: revocation.time.to_s,
+    extensions: revocation.extensions.map{ |ext| ext.to_h }
+  }
+} #.sort_by{ |r| r[:_____]}
 
-puts "... ISSUER: #{crl.issuer.to_s}"
-puts "... VERSION: #{crl.version.to_s}"
-puts "... LAST UPDATE: #{crl.last_update.to_s}"
-puts "... NEXT UPDATE: #{crl.next_update.to_s}"
-revoked_certs = crl.revoked # memoize for performance
-puts "... REVOKED CERTIFICATE COUNT: #{revoked_certs.count}"
+metadata = {
+  issuer: crl.issuer.to_s,
+  version: crl.version.to_s,
+  last_update: crl.last_update.to_s,
+  next_update: crl.next_update.to_s,
+  revocations_count: revocations.count,
+  earlist_revocation_at: revocations.first[:revoked_at],
+  latest_revocation_at: revocations.last[:revoked_at],
+  revocations: revocations
+}
 
-#puts "... LOOPING THROUGH REVOKED CERTIFICATES ..."
-
-#crl.revoked.each do |revoked_cert|
-#
-#end
-
-puts "INVESTIGATING FIRST CERTIFICATE..."
-
-r = revoked_certs.first
-
-puts "... SERIAL: #{r.serial.to_s}"
-puts "... TIME: #{r.time.to_s}"
-puts "... EXTENSIONS (#{r.extensions.count}):"
-r.extensions.each do |ext|
-  puts "   ... #{ext.to_h}"
-end
+pp metadata


### PR DESCRIPTION
Additions:

  + Parses a local `.crl` file and generates a `metadata.json` file (summary statistics) and a `revocations.csv` file (detailed list of info about revoked certs).

Considerations:

  + Writing revocations to CSV instead of JSON involves an awkward pipe-delimited `extensions` column, but reduces overall file size from 75M to 21M.